### PR TITLE
reset human interface devices only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,21 @@ Make arch-keyboard-fix.sh executable as program and run
 chmod +x arch-keyboard-fix.sh
 ./arch-keyboard-fix.sh
 ```
+WARNING: note that the current working directory must be the directory where `arch-keyboard-fix.sh` and the other files are located.
+
 Or you can execute all commands at once:
 ```
 git clone https://github.com/TheDragonary/Arch-Keyboard-Fix.git && cd Arch-Keyboard-Fix && chmod +x arch-keyboard-fix.sh && ./arch-keyboard-fix.sh && cd && rm -rf ~/Arch-Keyboard-Fix
 ```
+
+## How it works
+
+The fix involves three files:
+
+- [arch-keyboard-fix.sh](arch-keyboard-fix.sh) is the installation script.
+  It copies [reset-input-devices-after-sleep.service](reset-input-devices-after-sleep.service) and [reset-input-devices.sh](reset-input-devices.sh) where they belong.
+- [reset-input-devices-after-sleep.service](reset-input-devices-after-sleep.service) is a [systemd](https://wiki.archlinux.org/title/systemd) [service file](https://wiki.archlinux.org/title/systemd#Writing_unit_files).
+  It executes [reset-input-devices.sh](reset-input-devices.sh) after every suspend/hibernate.
+- [reset-input-devices.sh](reset-input-devices.sh) resets
+  - the [atkbd](https://www.kernel.org/doc/html/latest/input/input.html#atkbd) Linux kernel which is responsible for the built-in keyboard of laptops.
+  - all [USB human interface devices](https://en.wikipedia.org/wiki/USB_HID).

--- a/README.md
+++ b/README.md
@@ -6,16 +6,15 @@ Clone the repo
 ```
 git clone https://github.com/TheDragonary/Arch-Keyboard-Fix.git && cd Arch-Keyboard-Fix
 ```
-Make arch-keyboard-fix.sh executable as program and run
+and run
 ```
-chmod +x arch-keyboard-fix.sh
 ./arch-keyboard-fix.sh
 ```
 WARNING: note that the current working directory must be the directory where `arch-keyboard-fix.sh` and the other files are located.
 
 Or you can execute all commands at once:
 ```
-git clone https://github.com/TheDragonary/Arch-Keyboard-Fix.git && cd Arch-Keyboard-Fix && chmod +x arch-keyboard-fix.sh && ./arch-keyboard-fix.sh && cd && rm -rf ~/Arch-Keyboard-Fix
+git clone https://github.com/TheDragonary/Arch-Keyboard-Fix.git && cd Arch-Keyboard-Fix && ./arch-keyboard-fix.sh && cd && rm -rf ~/Arch-Keyboard-Fix
 ```
 
 ## How it works

--- a/arch-keyboard-fix.sh
+++ b/arch-keyboard-fix.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 sudo cp reset-input-devices.sh /usr/local/bin/
 sudo cp reset-input-devices-after-sleep.service /etc/systemd/system/
 

--- a/reset-input-devices.sh
+++ b/reset-input-devices.sh
@@ -1,4 +1,5 @@
-#! /bin/sh
+#!/usr/bin/env bash
+
 # Reset the keyboard driver and USB mouse 
         
 modprobe -r atkbd

--- a/reset-input-devices.sh
+++ b/reset-input-devices.sh
@@ -5,11 +5,12 @@ modprobe -r atkbd
 modprobe atkbd reset=1
 echo "Finished resetting the keyboard."
         
-# Reset every USB device, because we don't know in advance which port
-# the mouse is plugged into. Send errors to /dev/null to avoid 
-# cluttering up the logs.
-for USB in /sys/bus/usb/devices/*/authorized; do
-    eval "echo 0 > $USB" 2>/dev/null 
-    eval "echo 1 > $USB" 2>/dev/null
+# Reset all USB human interface devices
+for USB in /sys/bus/usb/devices/*; do
+    if [ "`realpath "$USB/driver"`" = '/sys/bus/usb/drivers/usbhid' ]; then
+        echo "Resetting USB human interface device $USB"
+        echo 0 > "$USB/authorized"
+        echo 1 > "$USB/authorized"
+    fi
 done
 echo "Finished resetting USB inputs."

--- a/reset-input-devices.sh
+++ b/reset-input-devices.sh
@@ -20,9 +20,13 @@ echo "Finished resetting the keyboard."
 reset_device()
 {
     local dev="$1"
+    if [ ! -w "$dev/authorized" ]; then
+        echo "Not resetting USB device $dev because $dev/authorized does not exist or is not writable"
+        return
+    fi
     echo "Resetting USB device $dev"
-    echo 0 > "$dev/authorized"
-    echo 1 > "$dev/authorized"
+    timeout 1s echo 0 > "$dev/authorized"
+    timeout 1s echo 1 > "$dev/authorized"
 }
 
 reset_parent_device()

--- a/reset-input-devices.sh
+++ b/reset-input-devices.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Reset the keyboard driver and USB mouse 
-        
+# Reset the keyboard driver and USB mouse
+
 modprobe -r atkbd
 modprobe atkbd reset=1
 echo "Finished resetting the keyboard."

--- a/reset-input-devices.sh
+++ b/reset-input-devices.sh
@@ -4,13 +4,37 @@
 modprobe -r atkbd
 modprobe atkbd reset=1
 echo "Finished resetting the keyboard."
-        
+
+
 # Reset all USB human interface devices
+
+# I don't know much about the USB protocol but
+# I have tried a keyboard, a mouse and a stick.
+# All of them showed up as one device with the driver /sys/bus/usb/drivers/usb
+# containing one or more devices with the expected driver
+# /sys/bus/usb/drivers/usbhid or /sys/bus/usb/drivers/usb-storage.
+# After resetting the HID only the keyboard did not work.
+# I needed to reset the parent device, too.
+
+reset_device()
+{
+    local dev="$1"
+    echo "Resetting USB device $dev"
+    echo 0 > "$dev/authorized"
+    echo 1 > "$dev/authorized"
+}
+
+reset_parent_device()
+{
+    local hid="$1"
+    local usb="${hid%:*}"
+    reset_device "$usb"
+}
+
 for USB in /sys/bus/usb/devices/*; do
     if [ "`realpath "$USB/driver"`" = '/sys/bus/usb/drivers/usbhid' ]; then
-        echo "Resetting USB human interface device $USB"
-        echo 0 > "$USB/authorized"
-        echo 1 > "$USB/authorized"
+        reset_device "$USB"
+        reset_parent_device "$USB"
     fi
 done
 echo "Finished resetting USB inputs."


### PR DESCRIPTION
Thank you for sharing this script.

The script reset all USB devices and resetting storage devices can cause loss of data.
Therefore I have added a check to reset human interface devices only.

I have also set the executable flag for arch-keyboard-fix.sh so that this does not need to be done manually after cloning any more and added some more documentation to the readme.

Unfortunately this script does not work for me because in my case the entire USB hub is missing from `/sys/bus/usb/devices/`.